### PR TITLE
Fix traditional BOM generation CI script XML BOM identification logic

### DIFF
--- a/ci/generate-traditional-boms
+++ b/ci/generate-traditional-boms
@@ -67,7 +67,7 @@ function generate_traditional_boms()
         fi
     done
 
-    local boms_xml; mapfile -t boms_xml < <( find "$repository" -name '*.xml' ); readonly boms_xml
+    local boms_xml; mapfile -t boms_xml < <( find "$repository/temp" -name '*.xml' ); readonly boms_xml
 
     for bom_xml in "${boms_xml[@]}"; do
         local bom; bom=$( basename "$bom_xml" .xml )


### PR DESCRIPTION
Resolves #28 (Fix traditional BOM generation CI script XML BOM
identification logic).

The traditional BOM generation CI script did not restrict its search for
XML BOMs to the directory where generated XML BOMs are placed. This
could result in other XML files being misidentified as XML BOMs.

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
